### PR TITLE
CFWheels 2.0 compatibility changes

### DIFF
--- a/FlashWrapper.cfc
+++ b/FlashWrapper.cfc
@@ -3,7 +3,7 @@
 	<cfinclude template="controller/flash.cfm" />
 
 	<cffunction name="init" access="public" >
-		<cfset this.version = "1.1.7" />
+		<cfset this.version = "2.0.0" />
 		<cfreturn this>
 	</cffunction>>
 </cfcomponent>

--- a/controller/flash.cfm
+++ b/controller/flash.cfm
@@ -144,7 +144,7 @@
 	<cfargument name="keys" type="string" required="false" hint="The key (or list of keys) to show the value for. You can also use the `key` argument instead for better readability when accessing a single key.">
 	<cfargument name="class" type="string" required="false" hint="HTML `class` to set on the `div` element that contains the messages.">
 	<cfargument name="includeEmptyContainer" type="boolean" required="false" hint="Includes the DIV container even if the flash is empty.">
-	<cfargument name="lowerCaseDynamicClassValues" type="boolean" required="false" hint="Outputs all class attribute values in lower case (except the main one).">
+	<cfargument name="encode" type="boolean" required="false" hint="When set to `true`, encodes tag content, attribute values, and URLs so that Cross Site Scripting (XSS) attacks can be prevented. Set to attributes to only encode `attribute` values and not tag content.">
 	<cfargument name="prependToValue" required="false" hint="String to prepend to each flash value. Useful to wrap each flash value with HTML tags.">
 	<cfargument name="appendToValue" required="false" hint="String to append to each flash value. Useful to wrap each flash value with HTML tags.">
 	<cfscript>
@@ -175,8 +175,6 @@
 		{
 			loc.item = ListGetAt(loc.flashKeys, loc.i);
 			loc.class = loc.item & "Message";
-			if (arguments.lowerCaseDynamicClassValues)
-				loc.class = LCase(loc.class);
 			loc.attributes = {class=loc.class};
 			if (!StructKeyExists(arguments, "key") || arguments.key == loc.item)
 			{

--- a/index.cfm
+++ b/index.cfm
@@ -2,7 +2,7 @@
 
 <cfscript>
 	flashWrapperMeta = {};
-	flashWrapperMeta.version = "0.1.1";
+	flashWrapperMeta.version = "0.1.2";
 	flashInsert(alert="flash(""alert"")");
 	flashInsert(error="flash(""error"")");
 	flashInsert(info="flash(""info"")");
@@ -21,13 +21,13 @@
 
 <h1>Flash Wrapper v#flashWrapperMeta.version#</h1>
 <p>
-	This plugin adds new parameters to <a href="http://cfwheels.org/docs/1-1/function/flash">flash()</a> and <a href="http://cfwheels.org/docs/1-1/function/flashmessages">flashMessages()</a> so their output can be wrapped with custom HTML.
+	This plugin adds new parameters to <a href="https://api.cfwheels.org/v2.0##controller.flash">flash()</a> and <a href="https://api.cfwheels.org/v2.0##controller.flashmessages">flashMessages()</a> so their output can be wrapped with custom HTML.
 </p>
 
 <h2>Usage/Examples</h2>
 <p>
 	<ul>
-		<li>Adds parameters <em>prepend</em> and <em>append</em> to <a href="http://cfwheels.org/docs/1-1/function/flash">flash()</a>. Here we can see <a href="http://cfwheels.org/docs/1-1/function/flash">flash()</a> surrounded by <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap</a> styled markup.</li>
+		<li>Adds parameters <em>prepend</em> and <em>append</em> to <a href="https://api.cfwheels.org/v2.0##controller.flash">flash()</a>. Here we can see <a href="https://api.cfwheels.org/v2.0##controller.flash">flash()</a> surrounded by <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap</a> styled markup.</li>
 		<li>If the flash key name is one of <em>error</em>, <em>info</em>, or <em>success</em>, and there is a class of <em>alert</em> existing in the <em>prepend</em> argument string, a <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap</a> compatible class of either <em>alert-error</em>, <em>alert-info</em>, or <em>alert-success</em> will be added to the element according to the flash key name.</li>
 	</ul>
 	#flash(key="alert", prepend="<div class=""alert"">", append="</div>")#
@@ -37,7 +37,7 @@
 </p>
 <p>
 	<ul>
-		<li>Adds parameters <em>prependToValue</em> and <em>appendToValue</em> to <a href="http://cfwheels.org/docs/1-1/function/flashmessages">flashMessages()</a>. Here we can see each message in <a href="http://cfwheels.org/docs/1-1/function/flashmessages">flashMessages()</a> surrounded by <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap</a> styled markup.</li>
+		<li>Adds parameters <em>prependToValue</em> and <em>appendToValue</em> to <a href="https://api.cfwheels.org/v2.0##controller.flashmessages">flashMessages()</a>. Here we can see each message in <a href="https://api.cfwheels.org/v2.0##controller.flashmessages">flashMessages()</a> surrounded by <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap</a> styled markup.</li>
 		<li>If a flash key name is one of <em>error</em>, <em>info</em>, or <em>success</em>, and there is a class of <em>alert</em> existing in the <em>prependToValue</em> argument string, a <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap</a> compatible class of either <em>alert-error</em>, <em>alert-info</em>, or <em>alert-success</em> will be added to the element according to the key name for each value in the flash.</li>
 	</ul>
 	#flashMessages(prependToValue="<div class=""alert"">", appendToValue="</div>")#
@@ -45,7 +45,7 @@
 
 <h2>Configuration</h2>
 <p>
-	Function default settings can be set from <tt>/config/settings.cfm</tt> or from any of the environment-specific settings files (e.g., <tt>/config/design/settings.cfm</tt>) using the <a href="http://cfwheels.org/docs/1-1/function/set">set()</a> function. Here we see an example using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap</a> styled markup.
+	Function default settings can be set from <tt>/config/settings.cfm</tt> or from any of the environment-specific settings files (e.g., <tt>/config/design/settings.cfm</tt>) using the <a href="https://api.cfwheels.org/v2.0##controller.set">set()</a> function. Here we see an example using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap</a> styled markup.
 </p>
 <pre>
 &lt;cfscript&gt;


### PR DESCRIPTION
Remove the lowerCaseDynamicClassValues attribute from the FlashMessages
function. Update the supported CFWheels version to 2.0.0. Update the
links in the plugin about page to point to the CfWheels 2.0 docs.